### PR TITLE
Add *.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .tmp/
+*.log


### PR DESCRIPTION
Avoids committing log files, eg. `yarn-error.log`.